### PR TITLE
펫 서비스 라우팅 추가 & userId 연결 

### DIFF
--- a/gateway-server/src/main/java/com/comepethome/gateway/filter/NoAuthenticationFilter.java
+++ b/gateway-server/src/main/java/com/comepethome/gateway/filter/NoAuthenticationFilter.java
@@ -1,16 +1,18 @@
 package com.comepethome.gateway.filter;
 
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.comepethome.gateway.jwt.JwtService;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
-import reactor.core.publisher.Mono;
-
 import java.util.Optional;
 
+@Slf4j
 @Component
 public class NoAuthenticationFilter extends AbstractGatewayFilterFactory<NoAuthenticationFilter.Config> {
     private final static String AUTH_ID = "Auth-Id";
@@ -18,7 +20,6 @@ public class NoAuthenticationFilter extends AbstractGatewayFilterFactory<NoAuthe
     private static final String REFRESH_TOKEN_SUBJECT = "refresh-token";
     @Autowired
     private final JwtService jwtService;
-
     @Autowired
     public NoAuthenticationFilter(JwtService jwtService){
         super(NoAuthenticationFilter.Config.class);
@@ -27,8 +28,20 @@ public class NoAuthenticationFilter extends AbstractGatewayFilterFactory<NoAuthe
 
     @Override
     public GatewayFilter apply(Config config) {
-        return (exchange, chain) -> chain.filter(exchange).then(Mono.fromRunnable(()->{
+        return (exchange, chain) ->{
                 ServerHttpResponse response = exchange.getResponse();
+                ServerHttpRequest request = exchange.getRequest();
+
+                //토큰에서 userId 꺼내서 헤더에 넣는다
+                Optional.ofNullable(request.getHeaders().getFirst("Authorization")).ifPresent(token-> {
+                    try {
+                        String userId = jwtService.getUserIdfromToken(token);
+                        request.mutate().header("userId", userId).build();
+                    } catch (JWTVerificationException e) {
+                        log.error("JWT Verification failed: {}", e.getMessage());
+                    }
+                });
+
                 Optional.ofNullable(response.getHeaders().getFirst(AUTH_ID)).ifPresent(userId -> {
 
                     String accessToken = jwtService.createAccessTokenWithPrefix(userId);
@@ -37,7 +50,8 @@ public class NoAuthenticationFilter extends AbstractGatewayFilterFactory<NoAuthe
                     response.getHeaders().add(ACCESS_TOKEN_SUBJECT, accessToken);
                     response.getHeaders().add(REFRESH_TOKEN_SUBJECT, refreshToken);
             });
-        }));
+         return chain.filter(exchange);
+        };
     }
 
     @Data

--- a/gateway-server/src/main/java/com/comepethome/gateway/jwt/JwtService.java
+++ b/gateway-server/src/main/java/com/comepethome/gateway/jwt/JwtService.java
@@ -10,13 +10,11 @@ import com.comepethome.gateway.jwt.dto.TokenDTO;
 import com.comepethome.gateway.jwt.exception.CustomHttpStatus;
 import com.comepethome.gateway.jwt.exception.token.UnexpectedRefreshTokenException;
 import com.comepethome.gateway.jwt.refreshToken.RefreshTokenManager;
-import org.springframework.http.server.reactive.ServerHttpResponse;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -107,6 +105,19 @@ public class JwtService {
                 .withClaim(USERNAME_CLAIM, username)
                 .sign(algorithm);
 
+    }
+    public String getUserIdfromToken(String token){
+        token = removePrefix(token);
+        try {
+            DecodedJWT decodedJWT = verifier.verify(token);
+            String userId = decodedJWT.getClaim("userId").asString();
+            return userId;
+        } catch (TokenExpiredException e) {
+            // Todo: 만료시 알림 해줘야하나..? or 비회원으로 들어가나
+            return null;
+        } catch (JWTVerificationException e) {
+            return null;
+        }
     }
 
     public TokenDTO reissue(String refreshTokenWithPrefix) {

--- a/gateway-server/src/main/resources/application.yml
+++ b/gateway-server/src/main/resources/application.yml
@@ -46,13 +46,13 @@ spring:
         - id: pet
           uri: http://172.18.0.8:3000
           predicates:
-            - Path=/pets
+            - Path=/pets/**, /api-docs/**
           filters:
             - NoAuthenticationFilter
 
 jwt:
   properties:
-    secret: 123
+    secret: 12312421t34wrasdfoiapdfia9enawiefnaisnfwinfoaisdpoae123132123
     access-token-expiration-seconds: 60 # 900 10?
     refresh-token-expiration-seconds: 180 # 3600 1??
     token-prefix: Bearer


### PR DESCRIPTION
Description
---
- NoAuth 필터에서 토큰 복호화 후 헤더에 붙임, 테스팅 완료 (펫 서비스에서 개인 서비스로 바로 연결해서 사용)
- 게이트웨이 라우팅 추가 ( 변경 가능성 있음)
- secret key 변경 ( HS256 알고리즘에서는 적정 길이 필요하다고 에러남, 변경가능)


확인 후 코드 궁금한 점이나 테스트코드 추가 필요하면 말씀해주세요